### PR TITLE
振り返りのノート作成時によく利用する項目をテンプレートとして登録できる機能

### DIFF
--- a/src/components/ApplicationLayout/Header.tsx
+++ b/src/components/ApplicationLayout/Header.tsx
@@ -37,6 +37,7 @@ export const Header: React.VFC<Props> = ({ pictureURL }) => {
         setState({
           userID: '',
           displayName: '',
+          photoURL: '',
         })
         setIsSignOut(true)
       })

--- a/src/components/ApplicationLayout/index.tsx
+++ b/src/components/ApplicationLayout/index.tsx
@@ -1,16 +1,19 @@
-import React from 'react'
+import React, { useContext } from 'react'
 import { Drawer, ListItem, makeStyles } from '@material-ui/core'
 import { Link } from 'react-router-dom'
 import { Header } from './Header'
+import { UserStateContext } from '../../components/UserStateContext'
+
 type Props = {
   children: React.ReactNode
 }
 
 export const ApplicationLayout: React.VFC<Props> = ({ children }) => {
+  const [state] = useContext(UserStateContext)
   const classes = useStyles()
   return (
     <div>
-      <Header pictureURL="https://pbs.twimg.com/profile_images/814133757/face_normal.jpg" />
+      <Header pictureURL={state.photoURL} />
       <Drawer
         variant="persistent"
         anchor="left"

--- a/src/components/UserStateContext/index.tsx
+++ b/src/components/UserStateContext/index.tsx
@@ -4,11 +4,13 @@ import { useCurrentUser, fetchUserProfile } from '../../domains/user/services'
 export type UserState = {
   userID: string
   displayName: string
+  photoURL: string
 }
 
 const initialState: UserState = {
   userID: '',
   displayName: '',
+  photoURL: '',
 }
 
 export const UserStateContext = createContext<
@@ -24,6 +26,7 @@ export const UserProvider: React.FC = ({ children }) => {
         const userProfile = await fetchUserProfile(`${userID}`)
         setState({
           userID,
+          photoURL: userProfile.photoURL || '',
           displayName: userProfile.displayName,
         })
       }

--- a/src/domains/note/services/index.ts
+++ b/src/domains/note/services/index.ts
@@ -14,6 +14,23 @@ export const createNote = async (data: NoteContent, uid: string) => {
   return response
 }
 
+export const createNoteTemplate = async (
+  data: NoteContent,
+  uid: string,
+  title: string
+) => {
+  const response = await firebase
+    .firestore()
+    .collection(`notes/${uid}/note_templates`)
+    .add({
+      title: 'test',
+      note: data,
+      createdAt: firebase.firestore.FieldValue.serverTimestamp(),
+      updatedAt: firebase.firestore.FieldValue.serverTimestamp(),
+    })
+  return response
+}
+
 export const fetchNotes = async (uid: string) => {
   const noteReference = await firebase
     .firestore()

--- a/src/domains/note/services/index.ts
+++ b/src/domains/note/services/index.ts
@@ -23,7 +23,7 @@ export const createNoteTemplate = async (
     .firestore()
     .collection(`notes/${uid}/note_templates`)
     .add({
-      title: 'test',
+      title: title,
       note: data,
       createdAt: firebase.firestore.FieldValue.serverTimestamp(),
       updatedAt: firebase.firestore.FieldValue.serverTimestamp(),
@@ -37,6 +37,27 @@ export const fetchNotes = async (uid: string) => {
     .collection(`notes/${uid}/pages`)
 
   const snapshot = await noteReference.get()
+  if (snapshot.empty) {
+    return []
+  }
+
+  const notes = snapshot.docs.map((doc: any) => {
+    const note = doc.data() as PageData
+    return {
+      ...note,
+      id: doc.id,
+      pageSummary: detectPageSummary(note.note),
+    }
+  })
+  return notes
+}
+
+export const fetchNoteTemplates = async (uid: string) => {
+  const noteTemplateReference = await firebase
+    .firestore()
+    .collection(`notes/${uid}/note_templates`)
+
+  const snapshot = await noteTemplateReference.get()
   if (snapshot.empty) {
     return []
   }

--- a/src/domains/sensitivity_setting/models/index.ts
+++ b/src/domains/sensitivity_setting/models/index.ts
@@ -1,12 +1,12 @@
 export type SensitivitySetting = {
-  buildModeSensitivity: number
-  editModeSensitivity: number
-  lookHorizontalSpeed: number
-  lookVerticalSpeed: number
-  turningHorizontalBoost: number
-  turningVerticalBoost: number
-  adsLookHorizontalSpeed: number
-  adsLookVerticalSpeed: number
-  adsTurningHorizontalBoost: number
-  adsTurningVerticalBoost: number
+  buildModeSensitivity: number // 建築感度
+  editModeSensitivity: number // 編集感度
+  lookHorizontalSpeed: number //水平感度
+  lookVerticalSpeed: number //垂直感度
+  turningHorizontalBoost: number // 水平ブースト
+  turningVerticalBoost: number // 垂直ブースト
+  adsLookHorizontalSpeed: number //ADS水平感度
+  adsLookVerticalSpeed: number //ADS垂直感度
+  adsTurningHorizontalBoost: number // ADS水平ブースト
+  adsTurningVerticalBoost: number // ADS垂直ブースト
 }

--- a/src/pages/admin/SignIn/index.tsx
+++ b/src/pages/admin/SignIn/index.tsx
@@ -31,6 +31,7 @@ export const SignIn: React.VFC = () => {
         setState({
           userID: userProfile.uid,
           displayName: userProfile.displayName || '',
+          photoURL: userProfile.photoURL || '',
         })
         setIsSignIn(true)
       }

--- a/src/pages/admin/notes/NewNote.tsx
+++ b/src/pages/admin/notes/NewNote.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useContext } from 'react'
 import { NewNoteTemplate } from '../../../templates/admin/notes/NewNoteTemplate'
-import { createNote } from '../../../domains/note/services'
+import { createNote, createNoteTemplate } from '../../../domains/note/services'
 import { NoteContent } from '../../../domains/note/models'
 import { UserStateContext } from '../../../components/UserStateContext'
 
@@ -12,11 +12,18 @@ export const NewNote: React.VFC = () => {
     const note = await createNote(data, state.userID)
     note ? setIsNoteCreated(true) : setIsNoteCreateionFailed(true)
   }
+  const onClickCreateTemplate = async (title: string, data: NoteContent) => {
+    console.log(data)
+    const noteTemplate = await createNoteTemplate(data, state.userID, title)
+    console.log(noteTemplate)
+    return noteTemplate
+  }
 
   return (
     <>
       <NewNoteTemplate
         onSubmit={onSubmit}
+        onClickCreateTemplate={onClickCreateTemplate}
         isNoteCreated={isNoteCreated}
         isNoteCreateionFailed={isNoteCreateionFailed}
       />

--- a/src/pages/admin/notes/NewNote.tsx
+++ b/src/pages/admin/notes/NewNote.tsx
@@ -1,27 +1,38 @@
-import React, { useState, useContext } from 'react'
+import React, { useState, useContext, useEffect } from 'react'
 import { NewNoteTemplate } from '../../../templates/admin/notes/NewNoteTemplate'
 import { createNote, createNoteTemplate } from '../../../domains/note/services'
-import { NoteContent } from '../../../domains/note/models'
+import { NoteContent, PageData } from '../../../domains/note/models'
+import { fetchNoteTemplates } from '../../../domains/note/services'
 import { UserStateContext } from '../../../components/UserStateContext'
 
 export const NewNote: React.VFC = () => {
+  const initialNotes: PageData[] = []
   const [isNoteCreated, setIsNoteCreated] = useState(false)
   const [isNoteCreateionFailed, setIsNoteCreateionFailed] = useState(false)
+  const [noteTemplates, setNoteTemplates] = useState(initialNotes)
   const [state] = useContext(UserStateContext)
+
+  useEffect(() => {
+    async function fetchData() {
+      const noteTemplates = await fetchNoteTemplates(state.userID)
+      setNoteTemplates(noteTemplates)
+    }
+    fetchData()
+  }, [])
+
   const onSubmit = async (data: NoteContent) => {
     const note = await createNote(data, state.userID)
     note ? setIsNoteCreated(true) : setIsNoteCreateionFailed(true)
   }
   const onClickCreateTemplate = async (title: string, data: NoteContent) => {
-    console.log(data)
     const noteTemplate = await createNoteTemplate(data, state.userID, title)
-    console.log(noteTemplate)
     return noteTemplate
   }
 
   return (
     <>
       <NewNoteTemplate
+        noteTemplates={noteTemplates}
         onSubmit={onSubmit}
         onClickCreateTemplate={onClickCreateTemplate}
         isNoteCreated={isNoteCreated}

--- a/src/templates/admin/notes/NewNoteTemplate/CreateTemplateModal.tsx
+++ b/src/templates/admin/notes/NewNoteTemplate/CreateTemplateModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { makeStyles, Input, Typography, Button, Modal } from '@material-ui/core'
 
@@ -16,13 +16,11 @@ const detectModalStyle = () => {
 type Props = {
   buttonLabel: string
   onClickCreateTemplate: (data: any) => void
-  isCloseModal: boolean
 }
 
 export const CreateTemplateModal: React.VFC<Props> = ({
   buttonLabel,
   onClickCreateTemplate,
-  isCloseModal,
 }) => {
   const classes = useStyles()
   const [title, setTitle] = useState('')
@@ -41,18 +39,13 @@ export const CreateTemplateModal: React.VFC<Props> = ({
   const onSubmit = () => {
     if (title !== '') {
       onClickCreateTemplate(title)
+      handleClose()
     }
+    handleClose()
   }
   const handleInputChange = (event: any) => {
     setTitle(event.target.value)
   }
-
-  useEffect(() => {
-    console.log(`isCloseModal is ${isCloseModal}`)
-    if (isCloseModal) {
-      setOpen(false)
-    }
-  }, [isCloseModal])
 
   return (
     <>

--- a/src/templates/admin/notes/NewNoteTemplate/CreateTemplateModal.tsx
+++ b/src/templates/admin/notes/NewNoteTemplate/CreateTemplateModal.tsx
@@ -1,13 +1,6 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import { useForm } from 'react-hook-form'
-import {
-  Grid,
-  Button,
-  makeStyles,
-  Input,
-  Typography,
-  Modal,
-} from '@material-ui/core'
+import { makeStyles, Input, Typography, Button, Modal } from '@material-ui/core'
 
 const detectModalStyle = () => {
   const top = 10
@@ -23,17 +16,18 @@ const detectModalStyle = () => {
 type Props = {
   buttonLabel: string
   onClickCreateTemplate: (data: any) => void
+  isCloseModal: boolean
 }
 
-export const SimpleModal: React.VFC<Props> = ({
+export const CreateTemplateModal: React.VFC<Props> = ({
   buttonLabel,
   onClickCreateTemplate,
+  isCloseModal,
 }) => {
   const classes = useStyles()
-  const [open, setOpen] = useState(false)
   const [title, setTitle] = useState('')
   const [modalStyle] = useState(detectModalStyle)
-  const { handleSubmit } = useForm()
+  const [open, setOpen] = useState(false)
   const handleOpen = () => {
     setOpen(true)
   }
@@ -41,6 +35,8 @@ export const SimpleModal: React.VFC<Props> = ({
   const handleClose = () => {
     setOpen(false)
   }
+
+  const { handleSubmit } = useForm()
 
   const onSubmit = () => {
     if (title !== '') {
@@ -51,19 +47,13 @@ export const SimpleModal: React.VFC<Props> = ({
     setTitle(event.target.value)
   }
 
-  const body = (
-    <div style={modalStyle} className={classes.paper}>
-      <Typography id="simple-modal-title" component="h5" variant="h5">
-        テンプレート
-      </Typography>
-      <form onSubmit={handleSubmit(onSubmit)}>
-        {/* register your input into the hook by invoking the "register" function */}
-        <Input value={title} onChange={handleInputChange} />
-        <input type="submit" />
-      </form>
-      <Typography component="p">テンプレートとして登録する</Typography>
-    </div>
-  )
+  useEffect(() => {
+    console.log(`isCloseModal is ${isCloseModal}`)
+    if (isCloseModal) {
+      setOpen(false)
+    }
+  }, [isCloseModal])
+
   return (
     <>
       <Button variant="contained" color="secondary" onClick={handleOpen}>
@@ -75,7 +65,17 @@ export const SimpleModal: React.VFC<Props> = ({
         aria-labelledby="simple-modal-title"
         aria-describedby="simple-modal-description"
       >
-        {body}
+        <div style={modalStyle} className={classes.paper}>
+          <Typography id="simple-modal-title" component="h5" variant="h5">
+            テンプレート
+          </Typography>
+          <form onSubmit={handleSubmit(onSubmit)}>
+            {/* register your input into the hook by invoking the "register" function */}
+            <Input value={title} onChange={handleInputChange} />
+            <input type="submit" />
+          </form>
+          <Typography component="p">テンプレートとして登録</Typography>
+        </div>
       </Modal>
     </>
   )

--- a/src/templates/admin/notes/NewNoteTemplate/FetchTemplateModal.tsx
+++ b/src/templates/admin/notes/NewNoteTemplate/FetchTemplateModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState } from 'react'
 import {
   makeStyles,
   Typography,
@@ -25,14 +25,12 @@ type Props = {
   noteTemplates: PageData[]
   buttonLabel: string
   onClick: (data: any) => void
-  isCloseModal: boolean
 }
 
 export const FetchTemplateModal: React.VFC<Props> = ({
   noteTemplates,
   buttonLabel,
   onClick,
-  isCloseModal,
 }) => {
   const classes = useStyles()
   const [modalStyle] = useState(detectModalStyle)
@@ -44,13 +42,10 @@ export const FetchTemplateModal: React.VFC<Props> = ({
   const handleClose = () => {
     setOpen(false)
   }
-
-  useEffect(() => {
-    console.log(`isCloseModal is ${isCloseModal}`)
-    if (isCloseModal) {
-      setOpen(false)
-    }
-  }, [isCloseModal])
+  const onHandleClose = (data: any) => {
+    onClick(data)
+    handleClose()
+  }
 
   return (
     <>
@@ -75,7 +70,7 @@ export const FetchTemplateModal: React.VFC<Props> = ({
                     button
                     data-id={noteTemplate.id}
                     key={noteTemplate.id}
-                    onClick={onClick}
+                    onClick={onHandleClose}
                   >
                     {noteTemplate.title}
                   </ListItem>

--- a/src/templates/admin/notes/NewNoteTemplate/FetchTemplateModal.tsx
+++ b/src/templates/admin/notes/NewNoteTemplate/FetchTemplateModal.tsx
@@ -1,0 +1,107 @@
+import React, { useState, useEffect } from 'react'
+import {
+  makeStyles,
+  Typography,
+  List,
+  ListItem,
+  Button,
+  Modal,
+} from '@material-ui/core'
+
+import { PageData } from '../../../../domains/note/models'
+
+const detectModalStyle = () => {
+  const top = 10
+  const left = 50
+
+  return {
+    top: `${top}%`,
+    left: `${left}%`,
+    transform: `translate(-${top}%, -${left}%)`,
+  }
+}
+
+type Props = {
+  noteTemplates: PageData[]
+  buttonLabel: string
+  onClick: (data: any) => void
+  isCloseModal: boolean
+}
+
+export const FetchTemplateModal: React.VFC<Props> = ({
+  noteTemplates,
+  buttonLabel,
+  onClick,
+  isCloseModal,
+}) => {
+  const classes = useStyles()
+  const [modalStyle] = useState(detectModalStyle)
+  const [open, setOpen] = useState(false)
+  const handleOpen = () => {
+    setOpen(true)
+  }
+
+  const handleClose = () => {
+    setOpen(false)
+  }
+
+  useEffect(() => {
+    console.log(`isCloseModal is ${isCloseModal}`)
+    if (isCloseModal) {
+      setOpen(false)
+    }
+  }, [isCloseModal])
+
+  return (
+    <>
+      <Button variant="contained" color="secondary" onClick={handleOpen}>
+        {buttonLabel}
+      </Button>
+      <Modal
+        open={open}
+        onClose={handleClose}
+        aria-labelledby="simple-modal-title"
+        aria-describedby="simple-modal-description"
+      >
+        <div style={modalStyle} className={classes.paper}>
+          <Typography id="simple-modal-title" component="h5" variant="h5">
+            登録済のテンプレート一覧
+          </Typography>
+          <div className={classes.root}>
+            <List component="nav" aria-label="main mailbox folders">
+              {noteTemplates.map((noteTemplate) => {
+                return (
+                  <ListItem
+                    button
+                    data-id={noteTemplate.id}
+                    key={noteTemplate.id}
+                    onClick={onClick}
+                  >
+                    {noteTemplate.title}
+                  </ListItem>
+                )
+              })}
+            </List>
+          </div>
+        </div>
+      </Modal>
+    </>
+  )
+}
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    width: '100%',
+    maxWidth: 360,
+    backgroundColor: theme.palette.background.paper,
+  },
+  paper: {
+    position: 'absolute',
+    width: 400,
+    minHeight: 200,
+    backgroundColor: theme.palette.background.paper,
+    border: '2px solid #000',
+    boxShadow: theme.shadows[5],
+    padding: theme.spacing(2, 4, 3),
+  },
+}))

--- a/src/templates/admin/notes/NewNoteTemplate/SimpleModal.tsx
+++ b/src/templates/admin/notes/NewNoteTemplate/SimpleModal.tsx
@@ -1,0 +1,94 @@
+import React, { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import {
+  Grid,
+  Button,
+  makeStyles,
+  Input,
+  Typography,
+  Modal,
+} from '@material-ui/core'
+
+const detectModalStyle = () => {
+  const top = 10
+  const left = 50
+
+  return {
+    top: `${top}%`,
+    left: `${left}%`,
+    transform: `translate(-${top}%, -${left}%)`,
+  }
+}
+
+type Props = {
+  buttonLabel: string
+  onClickCreateTemplate: (data: any) => void
+}
+
+export const SimpleModal: React.VFC<Props> = ({
+  buttonLabel,
+  onClickCreateTemplate,
+}) => {
+  const classes = useStyles()
+  const [open, setOpen] = useState(false)
+  const [title, setTitle] = useState('')
+  const [modalStyle] = useState(detectModalStyle)
+  const { handleSubmit } = useForm()
+  const handleOpen = () => {
+    setOpen(true)
+  }
+
+  const handleClose = () => {
+    setOpen(false)
+  }
+
+  const onSubmit = () => {
+    if (title !== '') {
+      onClickCreateTemplate(title)
+    }
+  }
+  const handleInputChange = (event: any) => {
+    setTitle(event.target.value)
+  }
+
+  const body = (
+    <div style={modalStyle} className={classes.paper}>
+      <Typography id="simple-modal-title" component="h5" variant="h5">
+        テンプレート
+      </Typography>
+      <form onSubmit={handleSubmit(onSubmit)}>
+        {/* register your input into the hook by invoking the "register" function */}
+        <Input value={title} onChange={handleInputChange} />
+        <input type="submit" />
+      </form>
+      <Typography component="p">テンプレートとして登録する</Typography>
+    </div>
+  )
+  return (
+    <>
+      <Button variant="contained" color="secondary" onClick={handleOpen}>
+        {buttonLabel}
+      </Button>
+      <Modal
+        open={open}
+        onClose={handleClose}
+        aria-labelledby="simple-modal-title"
+        aria-describedby="simple-modal-description"
+      >
+        {body}
+      </Modal>
+    </>
+  )
+}
+
+const useStyles = makeStyles((theme) => ({
+  paper: {
+    position: 'absolute',
+    width: 400,
+    minHeight: 200,
+    backgroundColor: theme.palette.background.paper,
+    border: '2px solid #000',
+    boxShadow: theme.shadows[5],
+    padding: theme.spacing(2, 4, 3),
+  },
+}))

--- a/src/templates/admin/notes/NewNoteTemplate/index.tsx
+++ b/src/templates/admin/notes/NewNoteTemplate/index.tsx
@@ -5,15 +5,20 @@ import 'react-draft-wysiwyg/dist/react-draft-wysiwyg.css'
 import { Grid, Button, makeStyles, Box, Typography } from '@material-ui/core'
 
 import { useEditorState } from './useEditorState'
+import { SimpleModal } from './SimpleModal'
 import { FortniteNoteAlert } from '../../../../components/FortniteNoteAlert'
+import { NoteContent } from '../../../../domains/note/models'
+
 type Props = {
   onSubmit: (data: any) => void
+  onClickCreateTemplate: (title: string, data: any) => void
   isNoteCreated: boolean
   isNoteCreateionFailed: boolean
 }
 
 export const NewNoteTemplate: React.VFC<Props> = ({
   onSubmit,
+  onClickCreateTemplate,
   isNoteCreated,
   isNoteCreateionFailed,
 }) => {
@@ -24,6 +29,13 @@ export const NewNoteTemplate: React.VFC<Props> = ({
     event.preventDefault()
     const rawEditorData = convertToRaw(editorState.getCurrentContent())
     onSubmit(rawEditorData)
+  }
+
+  const onHandleCreateTemplate = (title: string) => {
+    const rawEditorData = convertToRaw(editorState.getCurrentContent())
+
+    console.log(rawEditorData)
+    onClickCreateTemplate(title, rawEditorData)
   }
 
   return (
@@ -44,9 +56,10 @@ export const NewNoteTemplate: React.VFC<Props> = ({
           alignItems="flex-end"
         >
           <Grid item>
-            <Button variant="contained" color={'secondary'}>
-              テンプレートを登録
-            </Button>
+            <SimpleModal
+              buttonLabel="テンプレートとして登録"
+              onClickCreateTemplate={onHandleCreateTemplate}
+            />
           </Grid>
           <Grid item>
             <Box p={1} />

--- a/src/templates/admin/notes/NewNoteTemplate/index.tsx
+++ b/src/templates/admin/notes/NewNoteTemplate/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React from 'react'
 import { convertToRaw, convertFromRaw, EditorState } from 'draft-js'
 import { Editor } from 'react-draft-wysiwyg'
 import 'react-draft-wysiwyg/dist/react-draft-wysiwyg.css'
@@ -27,20 +27,16 @@ export const NewNoteTemplate: React.VFC<Props> = ({
 }) => {
   const classes = useStyles()
   const { editorState, onChange } = useEditorState()
-  const [isCreateModalClose, setIsCreateModalClose] = useState(false)
-  const [isFetchModalClose, setIsFetchModalClose] = useState(false)
 
   const onHandleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault()
     const rawEditorData = convertToRaw(editorState.getCurrentContent())
     onSubmit(rawEditorData.entityMap)
-    setIsCreateModalClose(false)
   }
 
   const onHandleCreateTemplate = (title: string) => {
     const rawEditorData = convertToRaw(editorState.getCurrentContent())
     onClickCreateTemplate(title, rawEditorData)
-    setIsCreateModalClose(false)
   }
 
   const onHandleLoadTemplate = (event: any) => {
@@ -57,7 +53,6 @@ export const NewNoteTemplate: React.VFC<Props> = ({
         })
       )
       onChange(state)
-      setIsFetchModalClose(true)
     }
   }
 
@@ -82,7 +77,6 @@ export const NewNoteTemplate: React.VFC<Props> = ({
             <CreateTemplateModal
               buttonLabel="テンプレートとして登録"
               onClickCreateTemplate={onHandleCreateTemplate}
-              isCloseModal={isCreateModalClose}
             />
           </Grid>
           <Grid item>
@@ -93,7 +87,6 @@ export const NewNoteTemplate: React.VFC<Props> = ({
               noteTemplates={noteTemplates}
               buttonLabel="テンプレートを呼び出す"
               onClick={onHandleLoadTemplate}
-              isCloseModal={isFetchModalClose}
             />
           </Grid>
         </Grid>

--- a/src/templates/admin/notes/NewSensitivitySettingTemplate/index.tsx
+++ b/src/templates/admin/notes/NewSensitivitySettingTemplate/index.tsx
@@ -11,24 +11,13 @@ type Props = {
   isSensitivitySettingCreated: boolean
   isSensitivitySettingCreateionFailed: boolean
 }
-type Inputs = {
-  buildModeSensitivity: number // 建築感度
-  editModeSensitivity: number // 編集感度
-  lookHorizontalSpeed: number //水平感度
-  lookVerticalSpeed: number //垂直感度
-  turningHorizontalBoost: number // 水平ブースト
-  turningVerticalBoost: number // 垂直ブースト
-  adsLookHorizontalSpeed: number //ADS水平感度
-  adsLookVerticalSpeed: number //ADS垂直感度
-  adsTurningHorizontalBoost: number // ADS水平ブースト
-  adsTurningVerticalBoost: number // ADS垂直ブースト
-}
+
 export const NewSensitivitySettingTemplate: React.VFC<Props> = ({
   onSubmit,
   isSensitivitySettingCreated,
   isSensitivitySettingCreateionFailed,
 }) => {
-  const { control, handleSubmit } = useForm<Inputs>()
+  const { control, handleSubmit } = useForm<SensitivitySetting>()
   const [buildModeSensitivity, setBuildModeSensitivity] = useState(1.0)
   const [editModeSensitivity, setEditModeSensitivity] = useState(1.0)
   const [lookHorizontalSpeed, setLookHorizontalSpeed] = useState(20)


### PR DESCRIPTION
## このPRについて

issue #19 対応


## 画面

登録時の処理
![capture 2021-06-04 15 15 24](https://user-images.githubusercontent.com/950924/120754535-c39b0b00-c547-11eb-85af-5184fa3fd7df.png)

登録済のテンプレートを適用する

modal | クリック後の画面
--|--
![capture 2021-06-04 15 15 31](https://user-images.githubusercontent.com/950924/120754543-c564ce80-c547-11eb-9778-575d473f5546.png) | ![capture 2021-06-04 15 16 07](https://user-images.githubusercontent.com/950924/120754575-ceee3680-c547-11eb-809d-9402811bc9d5.png)
